### PR TITLE
Use correct attribute for repository name

### DIFF
--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -18,7 +18,7 @@ module.exports = {
                 + " pushed changes into "
                 + event.push.changes[0].new.type + " "
                 + link(event.push.changes[0].new, event.push.changes[0].new.name)
-                + " in repository " + link(event.repository);
+                + " in repository " + link(event.repository, event.repository.name);
   },
 
   handleIssueCreated: function handleIssueCreated(event) {

--- a/test/handlers.js
+++ b/test/handlers.js
@@ -28,7 +28,7 @@ describe('handlers.js', function() {
           }]
         },
         repository: {
-          title: "Repository 1",
+          name: "Repository 1",
           links: {
             html: {
               href: "http://repository1.com"
@@ -59,7 +59,7 @@ describe('handlers.js', function() {
           }]
         },
         repository: {
-          title: "Repository 1",
+          name: "Repository 1",
           links: {
             html: {
               href: "http://repository1.com"


### PR DESCRIPTION
Wrong attribute was used to set title for a repository link.